### PR TITLE
Fix GrowthScreen timer picker's confirm update

### DIFF
--- a/features/growth/components/DurationPickerModal.tsx
+++ b/features/growth/components/DurationPickerModal.tsx
@@ -94,6 +94,9 @@ export default function DurationPickerModal({
     } catch (error) {
       console.error('Failed to save duration:', error);
     }
+    // 変更が確実に親に反映されるよう、最新の値を通知
+    onChangeHours(internalHours);
+    onChangeMinutes(internalMinutes);
     onConfirm();
   };
 


### PR DESCRIPTION
## Summary
- ensure selected hours/minutes are pushed to parent state when confirming the picker

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847f960f47c8326b92015afaabffcd0